### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ An MCP server to query the Edinburgh Festivals API for information about events 
 
 Note that access to  Fringe event data for 2025 is not yet supported; this requires approval.
 
+<a href="https://glama.ai/mcp/servers/@richarda23/edfest-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@richarda23/edfest-mcp/badge" alt="Edinburgh Festivals Server MCP server" />
+</a>
 
 ## Tools
 


### PR DESCRIPTION
This PR adds a badge for the [Edinburgh Festivals MCP Server](https://glama.ai/mcp/servers/@richarda23/edfest-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@richarda23/edfest-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@richarda23/edfest-mcp/badge" alt="Edinburgh Festivals Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.